### PR TITLE
Small UI improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ cmake-build-release
 cmake-build-release-*
 cmake-build-debug-*
 compile_commands.json
+.vscode/c_cpp_properties.json 
+.vscode/settings.json

--- a/include/game/voxelscape.h
+++ b/include/game/voxelscape.h
@@ -20,7 +20,7 @@ private:
     entt::registry buildingRegistry;
 
     void renderEditorGUI(UIContext& uiState);
-    void renderMainMenu(UIContext& uiState, WorldContext& worldContext);
+    void renderMainMenu(UIContext& uiState);
     void renderGameGUI(UIContext& uiState);
     void renderGameConfigGUI(UIContext& uiState);
     void renderLoading(UIContext& uiState);

--- a/include/game/voxelscape.h
+++ b/include/game/voxelscape.h
@@ -4,6 +4,7 @@
 #include "core/vs_app.h"
 #include "core/vs_game.h"
 #include "game/components/ui_context.h"
+#include "game/components/world_context.h"
 
 class Voxelscape : public VSGame
 {
@@ -19,7 +20,7 @@ private:
     entt::registry buildingRegistry;
 
     void renderEditorGUI(UIContext& uiState);
-    void renderMainMenu(UIContext& uiState);
+    void renderMainMenu(UIContext& uiState, WorldContext& worldContext);
     void renderGameGUI(UIContext& uiState);
     void renderGameConfigGUI(UIContext& uiState);
     void renderLoading(UIContext& uiState);

--- a/source/game/systems/menu_system.cpp
+++ b/source/game/systems/menu_system.cpp
@@ -7,6 +7,7 @@
 #include "world/generator/vs_terrain.h"
 #include "game/systems/upgrade_system.h"
 #include "game/systems/delete_system.h"
+#include "ui/vs_parser.h"
 #include "core/vs_app.h"
 
 void updateMenuSystem(entt::registry& mainRegistry, entt::registry& buildingRegistry)
@@ -183,17 +184,27 @@ void updateMenuSystem(entt::registry& mainRegistry, entt::registry& buildingRegi
         uiContext.bShouldGenerateTerrain = false;
 
         uiContext.bShowLoading = true;
-        if (uiContext.selectedBiomeType == 0)
+        if (!uiContext.bShouldLoadFromFile)
         {
-            VSTerrainGeneration::buildStandard(world);
+            if (uiContext.selectedBiomeType == 0)
+            {
+                VSTerrainGeneration::buildStandard(world);
+            }
+            else if (uiContext.selectedBiomeType == 1)
+            {
+                VSTerrainGeneration::buildMountains(world);
+            }
+            else if (uiContext.selectedBiomeType == 2)
+            {
+                VSTerrainGeneration::buildDesert(world);
+            }
         }
-        else if (uiContext.selectedBiomeType == 1)
+        if (uiContext.bShouldLoadFromFile)
         {
-            VSTerrainGeneration::buildMountains(world);
-        }
-        else if (uiContext.selectedBiomeType == 2)
-        {
-            VSTerrainGeneration::buildDesert(world);
+            auto* app = VSApp::getInstance();
+            VSChunkManager::VSWorldData worldData = VSParser::readFromFile(uiContext.loadFilePath);
+            worldContext.world->getChunkManager()->initFromData(worldData);
+            uiContext.bShouldLoadFromFile = false;
         }
         uiContext.bShowLoading = false;
 

--- a/source/game/voxelscape.cpp
+++ b/source/game/voxelscape.cpp
@@ -171,7 +171,7 @@ void Voxelscape::renderUI()
     }
     else if (uiContext.bMenuActive)
     {
-        renderMainMenu(uiContext, worldContext);
+        renderMainMenu(uiContext);
     }
     else if (uiContext.bGameConfigActive)
     {
@@ -274,7 +274,7 @@ void Voxelscape::renderEditorGUI(UIContext& uiState)
     }
 }
 
-void Voxelscape::renderMainMenu(UIContext& uiState, WorldContext& worldContext)
+void Voxelscape::renderMainMenu(UIContext& uiState)
 {
     ImGui::PushFont(uiState.menuFont);
     ImGui::SetNextWindowPos(

--- a/source/game/voxelscape.cpp
+++ b/source/game/voxelscape.cpp
@@ -158,6 +158,7 @@ void Voxelscape::update(float deltaSeconds)
 void Voxelscape::renderUI()
 {
     auto& uiContext = mainRegistry.ctx().get<UIContext>();
+    auto& worldContext = mainRegistry.ctx().get<WorldContext>();
 
     if (uiContext.bEditorActive)
     {
@@ -170,7 +171,7 @@ void Voxelscape::renderUI()
     }
     else if (uiContext.bMenuActive)
     {
-        renderMainMenu(uiContext);
+        renderMainMenu(uiContext, worldContext);
     }
     else if (uiContext.bGameConfigActive)
     {
@@ -210,6 +211,12 @@ void Voxelscape::renderEditorMenu(UIContext& uiState)
                 uiState.bFileBrowserActive = true;
                 uiState.saveBuildingDialog->SetTitle("Save building");
                 uiState.saveBuildingDialog->Open();
+            }
+            if (ImGui::MenuItem("Close"))
+            {
+                uiState.bEditorActive = false;
+                uiState.bMenuActive = true;
+                getApp()->setWorldActive(uiState.menuWorldName);
             }
             ImGui::EndMenu();
         }
@@ -267,7 +274,7 @@ void Voxelscape::renderEditorGUI(UIContext& uiState)
     }
 }
 
-void Voxelscape::renderMainMenu(UIContext& uiState)
+void Voxelscape::renderMainMenu(UIContext& uiState, WorldContext& worldContext)
 {
     ImGui::PushFont(uiState.menuFont);
     ImGui::SetNextWindowPos(
@@ -296,12 +303,31 @@ void Voxelscape::renderMainMenu(UIContext& uiState)
         uiState.bGameConfigActive = true;
         uiState.bMenuActive = false;
     }
+    if (ImGui::Button("Load Game", ImVec2(ImGui::GetWindowContentRegionWidth(), 0.F)))
+    {
+        // Open File dialog
+        uiState.bFileBrowserActive = true;
+        uiState.loadFileDialog->SetTitle("Load scene file");
+        uiState.loadFileDialog->SetTypeFilters({".json"});
+        uiState.loadFileDialog->Open();
+    }
     if (ImGui::Button("Start Editor", ImVec2(ImGui::GetWindowContentRegionWidth(), 0.F)))
     {
         uiState.bShouldSetEditorActive = true;
     }
     ImGui::End();
     ImGui::PopFont();
+    uiState.loadFileDialog->Display();
+    if (uiState.loadFileDialog->HasSelected())
+    {
+        // Load scene
+        uiState.loadFilePath = uiState.loadFileDialog->GetSelected();
+        uiState.bShouldLoadFromFile = true;
+        uiState.bFileBrowserActive = false;
+        uiState.bMenuActive = false;
+        uiState.loadFileDialog->ClearSelected();
+        uiState.bShouldStartGame = true;
+    }
 }
 
 void Voxelscape::renderGameConfigGUI(UIContext& uiState)
@@ -341,7 +367,23 @@ void Voxelscape::renderGameGUI(UIContext& uiState)
     float menuBarHeight = 0.F;
     if (ImGui::BeginMainMenuBar())
     {
-        ImGui::MenuItem("Dummy");
+        if (ImGui::BeginMenu("File..."))
+        {
+            if (ImGui::MenuItem("Save world..."))
+            {
+                // Open File dialog
+                uiState.bFileBrowserActive = true;
+                uiState.saveFileDialog->SetTitle("Save scene file");
+                uiState.saveFileDialog->Open();
+            }
+            if (ImGui::MenuItem("Close"))
+            {
+                uiState.bShouldSetGameActive = false;
+                uiState.bMenuActive = true;
+                getApp()->setWorldActive(uiState.menuWorldName);
+            }
+            ImGui::EndMenu();
+        }
         ImGui::Separator();
         ImGui::Text("Unemployed: %i", uiState.populationSpace);
         ImGui::Image((void*)(intptr_t)uiState.woodResourceTexture, ImVec2(20, 20));


### PR DESCRIPTION
This will add a way to save the game while playing. This uses the same method as the editor, so player and building information does not get saved, and there is a new load button on the main menu which works in the same way as the editor.

**New menu**

![image](https://github.com/lolleko/voxelscape/assets/41990982/5bdeaa27-ba98-4d92-8685-43e49e792b45)

**New dropdown**

![image](https://github.com/lolleko/voxelscape/assets/41990982/c8f1a9d5-2017-43c6-a097-a2cbfae8bf5f)


<br>
<hr>

In the future there should be a new save file format, the current one only stores the information about voxels and not anything else. Also for a large world saving can take a long time, so only modified chunks could be saved instead (and the world seed). Player data could be stored in another file so there is not a massive JSON file. All the files will be saved in a per world folder (similar to Minecraft) (so there will need to be a new world loading/saving window). Instead of saving raw JSON files, you could use some form of compression to make files smaller. Minecraft uses the Named Binary Tag (NBT) format ([here's a C++ NBT library I found](https://github.com/handtruth/nbt-cpp)).